### PR TITLE
Use git+https instead of git+ssh for samson

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "rocket 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_codegen 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_contrib 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "samson 0.1.0 (git+ssh://git@github.com/lakinwecker/samson.git)",
+ "samson 0.1.0 (git+https://github.com/lakinwecker/samson.git)",
  "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "samson"
 version = "0.1.0"
-source = "git+ssh://git@github.com/lakinwecker/samson.git#0ae15c75f9af4de2de78e39ce46bf1fe8a2b3dbd"
+source = "git+https://github.com/lakinwecker/samson.git#0ae15c75f9af4de2de78e39ce46bf1fe8a2b3dbd"
 dependencies = [
  "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -873,7 +873,7 @@ dependencies = [
 "checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
 "checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
-"checksum samson 0.1.0 (git+ssh://git@github.com/lakinwecker/samson.git)" = "<none>"
+"checksum samson 0.1.0 (git+https://github.com/lakinwecker/samson.git)" = "<none>"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)" = "a702319c807c016e51f672e5c77d6f0b46afddd744b5e437d6b8436b888b458f"
 "checksum serde_codegen_internals 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d52006899f910528a10631e5b727973fe668f3228109d1707ccf5bad5490b6e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Lakin Wecker <lakin@structuredabstraction.com>"]
 
 [dependencies]
-samson = { git = "ssh://git@github.com/lakinwecker/samson.git" }
+samson = { git = "https://github.com/lakinwecker/samson.git" }
 diesel = { version = "0.9.0", features = ["chrono"] }
 diesel_codegen = { version = "0.9.0", features = ["sqlite"] }
 dotenv = "0.8.0"


### PR DESCRIPTION
Via git+ssh I get:

```
cargo run
    Updating git repository `ssh://git@github.com/lakinwecker/samson.git`
error: failed to load source for a dependency on `samson`
```